### PR TITLE
Removing list id on task creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Send a POST request to create a list task
 {
     "name": "task one",
     "description": "description of the first task",
-    "due_date": "date_time"
+    "due_date": "2018-12-08"
 }
 
   ```
@@ -366,7 +366,7 @@ Send a POST request to create a list task
     "name": "task_uno",
     "description": "description of the first task",
     "completed": "false",
-    "due_date": "date_time"
+    "due_date": "2018-12-08"
   }
 
   ```

--- a/spec/requests/api/v1/tasks/task_creation_spec.rb
+++ b/spec/requests/api/v1/tasks/task_creation_spec.rb
@@ -4,19 +4,20 @@ RSpec.describe 'Tasks API' do
   it 'can create a new task' do
     client = create(:client)
     list = List.create(name: 'list numero uno', client_id: "#{client.id}")
+
     task_params = {
-      list_id: "#{list.id}",
       description: 'first task description',
       name: 'task uno',
       completed: 'false',
       due_date: Date.tomorrow
     }.to_json
+
     headers = { 'CONTENT_TYPE' => 'application/json'}
 
     post "/api/v1/clients/#{client.id}/lists/#{list.id}/tasks", params: task_params, headers: headers
 
     data = JSON.parse(response.body)
-    task = Task.last
+    task = Task.find(data['id'])
 
     expect(data['name']).to eq('task uno')
     expect(data['description']).to eq('first task description')
@@ -26,6 +27,7 @@ RSpec.describe 'Tasks API' do
     expect(task.description).to eq('first task description')
     expect(task.name).to eq('task uno')
     expect(task.completed).to be false
+    expect(list.tasks).to include(task)
   end
 
     it 'recieves a 404 if list_id is invalid' do


### PR DESCRIPTION
## What functionality does this accomplish?
closes Trello Card: 
- remove list_id from required attributes when creating a task

*​*Description

- Removes list_id from task creation body in task creation spec
- Adds date format expectations to readme
​
## Current Test Suite:
### Test Coverage Percentage: 100%
- [ ] No Tests have been changed
- [x] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):
​
## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):
