### PR TITLE
Turning ablilities to array

### DIFF
--- a/app/controllers/api/v1/caretakers_controller.rb
+++ b/app/controllers/api/v1/caretakers_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::CaretakersController < ApplicationController
 
   def index
     caretakers = Caretaker.all
-    render json: caretakers, status: 200
+    render json: caretakers.map{|caretaker| CaretakerSerializer.new(caretaker)}, status: 200
   end
 
   def create
@@ -13,7 +13,7 @@ class Api::V1::CaretakersController < ApplicationController
       new_caretaker.update(abilities: abilities)
     end
     if new_caretaker.save
-      render json: new_caretaker, status: 201
+      render json: CaretakerSerializer.new(new_caretaker, params[:password]), status: 201
     else
       render json: new_caretaker.errors, status: 400
     end
@@ -22,7 +22,7 @@ class Api::V1::CaretakersController < ApplicationController
   def show
     if Caretaker.exists?(id: params['id'])
       caretaker = Caretaker.find(params['id'])
-      render json: caretaker, status: 200
+      render json: CaretakerSerializer.new(caretaker), status: 200
     else
       render json: { message: 'Invalid ID'}, status: 404
     end
@@ -38,7 +38,7 @@ class Api::V1::CaretakersController < ApplicationController
       abilities = params[:abilities].join(', ')
       caretaker.update(caretaker_params)
       caretaker.update(abilities: abilities)
-      render json: caretaker, status: 200
+      render json: CaretakerSerializer.new(caretaker), status: 200
     else
       render json: { message: "Invalid ID" }, status: 404
     end

--- a/app/controllers/api/v1/caretakers_controller.rb
+++ b/app/controllers/api/v1/caretakers_controller.rb
@@ -8,6 +8,10 @@ class Api::V1::CaretakersController < ApplicationController
 
   def create
     new_caretaker = Caretaker.new(caretaker_params)
+    if params[:abilities]
+      abilities = params[:abilities].join(', ')
+      new_caretaker.update(abilities: abilities)
+    end
     if new_caretaker.save
       render json: new_caretaker, status: 201
     else
@@ -31,7 +35,9 @@ class Api::V1::CaretakersController < ApplicationController
       render json: { message: "Email Must Be Unique" }, status: 404
     elsif Caretaker.exists?(id: params['id'])
       caretaker = Caretaker.find(params['id'])
+      abilities = params[:abilities].join(', ')
       caretaker.update(caretaker_params)
+      caretaker.update(abilities: abilities)
       render json: caretaker, status: 200
     else
       render json: { message: "Invalid ID" }, status: 404
@@ -48,7 +54,6 @@ class Api::V1::CaretakersController < ApplicationController
   private
 
   def caretaker_params
-    # is this still secure when I am not using the require method?
-    params.permit(:role, :username, :password, :password_confirmation, :name, :email, :phone_number, :abilities)
+    params.permit(:role, :username, :password, :password_confirmation, :name, :email, :phone_number)
   end
 end

--- a/app/serializers/caretaker_serializer.rb
+++ b/app/serializers/caretaker_serializer.rb
@@ -1,0 +1,12 @@
+class CaretakerSerializer
+  def initialize(caretaker, password=nil)
+    @id = caretaker.id
+    @username = caretaker.username
+    @password = password
+    @name = caretaker.name
+    @email = caretaker.email
+    @phone_number = caretaker.phone_number
+    @role = caretaker.role
+    @abilities = caretaker.abilities.split(', ') if caretaker.abilities
+  end
+end

--- a/spec/requests/api/v1/caretakers/caretaker_creation_spec.rb
+++ b/spec/requests/api/v1/caretakers/caretaker_creation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Caretakers API' do
       'name': 'caretaker_uno',
       'email': 'kate@email.com',
       'phone_number': '1234567891',
-      'abilities': 'ability_1',
+      'abilities': ['ability_1', 'ability_2'],
       'role': 'caretaker'
     }
 
@@ -44,10 +44,11 @@ RSpec.describe 'Caretakers API' do
     expect(data['name']).to eq('caretaker_uno')
     expect(data['email']).to eq('kate@email.com')
     expect(data['phone_number']).to eq('1234567891')
-    expect(data['abilities']).to eq('ability_1')
+    expect(data['abilities']).to eq(['ability_1', 'ability_2'])
     expect(data['role']).to eq('caretaker')
 
     expect(caretaker.role).to eq('caretaker')
+    expect(caretaker.abilities).to eq('ability_1, ability_2')
   end
 
   it 'recieves a 400 if username is not unique' do

--- a/spec/requests/api/v1/caretakers/caretaker_index_spec.rb
+++ b/spec/requests/api/v1/caretakers/caretaker_index_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Caretakers API' do
       'name': 'caretaker_dos',
       'email': 'kate2@email.com',
       'phone_number': '1234567891',
-      'abilities': 'ability_2, ability_2',
+      'abilities': 'ability_1, ability_2',
       'role': 'caretaker'
     })
   end

--- a/spec/requests/api/v1/caretakers/caretaker_index_spec.rb
+++ b/spec/requests/api/v1/caretakers/caretaker_index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Caretakers API' do
       'name': 'caretaker_uno',
       'email': 'kate@email.com',
       'phone_number': '1234567891',
-      'abilities': 'ability_1',
+      'abilities': 'ability_1, ability_2',
       'role': 'caretaker'
     }),
 
@@ -20,7 +20,7 @@ RSpec.describe 'Caretakers API' do
       'name': 'caretaker_dos',
       'email': 'kate2@email.com',
       'phone_number': '1234567891',
-      'abilities': 'ability_2',
+      'abilities': 'ability_2, ability_2',
       'role': 'caretaker'
     })
   end
@@ -33,13 +33,13 @@ RSpec.describe 'Caretakers API' do
     expect(data[0]['name']).to eq('caretaker_uno')
     expect(data[0]['email']).to eq('kate@email.com')
     expect(data[0]['phone_number']).to eq('1234567891')
-    expect(data[0]['abilities']).to eq('ability_1')
+    expect(data[0]['abilities']).to eq(['ability_1', 'ability_2'])
     expect(data[0]['role']).to eq('caretaker')
     expect(data[1]['username']).to eq('caretaker_2')
     expect(data[1]['name']).to eq('caretaker_dos')
     expect(data[1]['email']).to eq('kate2@email.com')
     expect(data[1]['phone_number']).to eq('1234567891')
-    expect(data[1]['abilities']).to eq('ability_2')
+    expect(data[1]['abilities']).to eq(['ability_1', 'ability_2'])
     expect(data[1]['role']).to eq('caretaker')
   end
 end

--- a/spec/requests/api/v1/caretakers/caretaker_show_spec.rb
+++ b/spec/requests/api/v1/caretakers/caretaker_show_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Caretakers API' do
       'name': 'caretaker_uno',
       'email': 'kate@email.com',
       'phone_number': '1234567891',
-      'abilities': 'ability_1',
+      'abilities': 'ability_1, ability_2',
       'role': 'caretaker'
     })
 
@@ -22,7 +22,7 @@ RSpec.describe 'Caretakers API' do
     expect(data['name']).to eq('caretaker_uno')
     expect(data['email']).to eq('kate@email.com')
     expect(data['phone_number']).to eq('1234567891')
-    expect(data['abilities']).to eq('ability_1')
+    expect(data['abilities']).to eq(['ability_1', 'ability_2'])
     expect(data['role']).to eq('caretaker')
   end
 

--- a/spec/requests/api/v1/caretakers/caretaker_update_spec.rb
+++ b/spec/requests/api/v1/caretakers/caretaker_update_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Caretakers API' do
       'name': 'updated_caretaker_uno',
       'email': 'updated_kate@email.com',
       'phone_number': 'updated_1234567891',
-      'abilities': 'updated_ability_1'
+      'abilities': ['updated_ability_1']
     }
 
     @caretaker_1 = Caretaker.create({
@@ -46,7 +46,7 @@ RSpec.describe 'Caretakers API' do
     expect(data['name']).to eq('updated_caretaker_uno')
     expect(data['email']).to eq('updated_kate@email.com')
     expect(data['phone_number']).to eq('updated_1234567891')
-    expect(data['abilities']).to eq('updated_ability_1')
+    expect(data['abilities']).to eq(['updated_ability_1'])
     expect(data['role']).to eq('caretaker')
   end
 


### PR DESCRIPTION
## What functionality does this accomplish?
closes Trello Cards: 

- Turn caretaker 'abilities' to array
​
**Description:**
​- Adds caretaker serializer to turn abilites to array for response
- Adjust caretakers controller for change in ability data type
  - 'ability' is still a string in the postgres db
​
## Current Test Suite:
### Test Coverage Percentage: 98%
- [ ] No Tests have been changed
- [x] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):
​
## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):
​
## Helpful Resources:
* Resource link AND small description of info gathered/learned