### PR TITLE
Caretaker tasks index

### DIFF
--- a/app/controllers/api/v1/caretakers/tasks_controller.rb
+++ b/app/controllers/api/v1/caretakers/tasks_controller.rb
@@ -1,15 +1,6 @@
 class Api::V1::Caretakers::TasksController < ApplicationController
   protect_from_forgery with: :null_session
 
-  # def create
-  #   new_task = Task.new(task_params)
-  #   if new_task.save
-  #     render json: TaskSerializer.new(new_task), status: 201
-  #   else
-  #     render json: new_task.errors, status: 404
-  #   end
-  # end
-
   def index
     # require 'pry'; binding.pry
     caretaker = Caretaker.find(params[:id])
@@ -18,27 +9,7 @@ class Api::V1::Caretakers::TasksController < ApplicationController
   rescue ActiveRecord::RecordNotFound
     render json: { message: "Not Found" }, status: 404
   end
-
-  # def update
-  #   client = Client.find(params[:client_id])
-  #   list = client.lists.find(params[:list_id])
-  #   task = list.tasks.find(params[:id])
-  #   task.update_attributes(task_params)
-  #   render json: TaskSerializer.new(task)
-  # rescue ActiveRecord::RecordNotFound
-  #   render json: { message: "Not Found" }, status: 404
-  # end
-
-  # def destroy
-  #   client = Client.find(params[:client_id])
-  #   list = client.lists.find(params[:list_id])
-  #   task = list.tasks.find(params[:id])
-  #   task.destroy
-  #   render json: {}, status: 204
-  # rescue ActiveRecord::RecordNotFound
-  #   render json: { message: "Not Found" }, status: 404
-  # end
-
+  
   private
 
   def task_params

--- a/app/controllers/api/v1/caretakers/tasks_controller.rb
+++ b/app/controllers/api/v1/caretakers/tasks_controller.rb
@@ -1,0 +1,47 @@
+class Api::V1::Caretakers::TasksController < ApplicationController
+  protect_from_forgery with: :null_session
+
+  # def create
+  #   new_task = Task.new(task_params)
+  #   if new_task.save
+  #     render json: TaskSerializer.new(new_task), status: 201
+  #   else
+  #     render json: new_task.errors, status: 404
+  #   end
+  # end
+
+  def index
+    # require 'pry'; binding.pry
+    caretaker = Caretaker.find(params[:id])
+    list = caretaker.lists.find(params[:list_id])
+    render json: list.tasks.map{|task| TaskSerializer.new(task)}
+  rescue ActiveRecord::RecordNotFound
+    render json: { message: "Not Found" }, status: 404
+  end
+
+  # def update
+  #   client = Client.find(params[:client_id])
+  #   list = client.lists.find(params[:list_id])
+  #   task = list.tasks.find(params[:id])
+  #   task.update_attributes(task_params)
+  #   render json: TaskSerializer.new(task)
+  # rescue ActiveRecord::RecordNotFound
+  #   render json: { message: "Not Found" }, status: 404
+  # end
+
+  # def destroy
+  #   client = Client.find(params[:client_id])
+  #   list = client.lists.find(params[:list_id])
+  #   task = list.tasks.find(params[:id])
+  #   task.destroy
+  #   render json: {}, status: 204
+  # rescue ActiveRecord::RecordNotFound
+  #   render json: { message: "Not Found" }, status: 404
+  # end
+
+  private
+
+  def task_params
+    params.permit(:description, :name, :completed, :due_date, :list_id)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
       # caretaker lists
       get '/caretakers/:id/lists', to: 'caretakers/lists#index'
 
+      # caretaker list tasks
+      get '/caretakers/:id/lists/:list_id/tasks', to: 'caretakers/tasks#index'
+
       post '/speech', to: 'speech#index'
       post '/login', to: 'login#create'
 

--- a/spec/requests/api/v1/caretakers/tasks/task_index_spec.rb
+++ b/spec/requests/api/v1/caretakers/tasks/task_index_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe "Caretaker Tasks API index endpoint" do
+  before :each do
+    @caretaker_1 = Caretaker.create({
+      'username': 'caretaker_1',
+      'password': 'password',
+      'password_confirmation': 'password',
+      'name': 'caretaker_uno', 
+      'email': 'kate@email.com',
+      'phone_number': '1234567891',
+      'abilities': 'ability_1'
+    })
+    @client = create(:client)
+    @list = create(:list, client: @client, caretaker_id: @caretaker_1.id)
+    @tastk1 = create(:task, list: @list)
+    @tastk2 = create(:task, list: @list)
+    @tastk3 = create(:task, list: @list)
+
+    @headers = {
+      accept: 'application/json',
+      content_type: 'application/json'
+    }
+
+  end
+  it "gets all tasks associated with a caretakers's list" do
+    get "/api/v1/caretakers/#{@caretaker_1.id}/lists/#{@list.id}/tasks", headers: @headers
+
+    expect(response).to be_successful
+    expect(status).to eq(200)
+
+    tasks = JSON.parse(response.body, symbolize_names: true)
+
+    expect(tasks).to be_a Array
+    expect(tasks.length).to eq(3)
+    expect(tasks.first).to have_key(:name)
+    expect(tasks.first).to have_key(:description)
+    expect(tasks.first).to have_key(:completed)
+    expect(tasks.first).to have_key(:due_date)
+    expect(tasks.first[:due_date]).to eq(Date.tomorrow.strftime("%m/%d"))
+    expect(tasks.first).to have_key(:list_id)
+    expect(tasks.first).to have_key(:created_at)
+    expect(tasks.first).to have_key(:updated_at)
+  end
+
+  it "returns 404 if caretaker id is invalid" do
+    get "/api/v1/clients/invalid_id/lists/#{@list.id}/tasks", headers: @headers
+
+    expect(status).to eq(404)
+
+    error = JSON.parse(response.body, symbolize_names: true)
+
+    expect(error[:message]).to eq("Not Found")
+  end
+
+  it "returns 404 if list id is invalid" do
+    get "/api/v1/clients/#{@client.id}/lists/invalid_id/tasks", headers: @headers
+
+    expect(status).to eq(404)
+
+    error = JSON.parse(response.body, symbolize_names: true)
+
+    expect(error[:message]).to eq("Not Found")
+  end
+end


### PR DESCRIPTION
## What functionality does this accomplish?
User can GET all tasks associated with a caretakers list

**Description:**
​When a user provides a valid caretaker ID, and list ID, makes a request to:
GET '/api/v1/caretakers/:id/lists/:list_id/tasks' 
A list of all the tasks associated to that list will be returned
If an invalid caretaker or list ID is provided, a 404 will be returned
​
## Current Test Suite:
### Test Coverage Percentage: 98.49%
- [ ] No Tests have been changed
- [x] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):
​
## Checklist:
- [ ] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):
​
## Helpful Resources:
* Resource link AND small description of info gathered/learned