### PR TITLE
Caretaker list show

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,15 @@ This is a unique opportunity that presents some valuable goals:
   - [Caretaker Deletion](#caretaker-deletion)
   - [All Caretakers](#all-caretakers)
   - [Caretaker Profile](#caretaker-profile)
-- Lists
+- Caretaker Lists
+  - [Caretaker List Show](#caretaker-list-show)
+  - [Caretaker List Index](#caretaker-list-index)
+- Client Lists
   - [List Creation](#list-creation)
   - [List Index](#list-index)
   - [List Update](#list-update)
   - [List Deletion](#list-deletion)
-- Tasks
+- Client Tasks
   - [List Tasks Creation](#list-task-creation)
   - [List Tasks Index](#list-tasks-index)
   - [List Tasks Update](#list-tasks-update)
@@ -413,6 +416,57 @@ Send a PATCH request to update a caretaker
   ```
   ##### Unsuccessful Response
   A valid caretaker ID must be provided otherwise a 404 status code (page not found) will be returned.
+
+## Caretaker List Show
+Send a GET request to get a single list associated with a caretaker
+
+  #### get /api/v1/caretakers/:id/lists/:list_id/
+
+  ##### Successful Response
+  ```json
+  {
+      "id": 1,
+      "name": "groceries",
+      "client_id": 2,
+      "caretaker_id": 4,
+      "created_at": "2019-09-04T22:14:25.439Z",
+      "updated_at": "2019-09-04T22:14:25.439Z"
+  }
+  ```
+
+  ##### Unsuccessful Response
+  A valid caretaker and list ID must be provided otherwise a 404 status code (page not found) will be returned. 
+
+## Caretaker List Index
+Send a GET request to get all the lists associated with a caretaker
+
+  #### get /api/v1/caretakers/:id/lists/
+
+
+  ##### Successful Response
+  ```json
+  [
+    {
+      "id": 1,
+      "name": "groceries",
+      "client_id": 2,
+      "caretaker_id": 4,
+      "created_at": "2019-09-04T22:14:25.439Z",
+      "updated_at": "2019-09-04T22:14:25.439Z"
+    },
+    {
+      "id": 2,
+      "name": "bills",
+      "client_id": 2,
+      "caretaker_id": 4,
+      "created_at": "2019-09-04T22:14:25.439Z",
+      "updated_at": "2019-09-04T22:14:25.439Z"
+    }
+  ]
+  ```
+
+  ##### Unsuccessful Response
+  A valid caretaker ID must be provided otherwise a 404 status code (page not found) will be returned. 
 
 ## List Creation
 Send a POST request to create a list for a client

--- a/app/controllers/api/v1/caretakers/lists_controller.rb
+++ b/app/controllers/api/v1/caretakers/lists_controller.rb
@@ -7,4 +7,15 @@ class Api::V1::Caretakers::ListsController < ApplicationController
   rescue ActiveRecord::RecordNotFound
     render json: { message: "Not Found" }, status: 404
   end
+
+  def show
+    caretaker = Caretaker.find(params[:id])
+    if list = caretaker.lists.find(params[:list_id])
+      render json: list, status: 200
+    else
+      render json: list.errors, status: 404
+    end
+  rescue ActiveRecord::RecordNotFound
+    render json: { message: "Not Found" }, status: 404
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
       # caretaker lists
       get '/caretakers/:id/lists', to: 'caretakers/lists#index'
+      get '/caretakers/:id/lists/:list_id', to: 'caretakers/lists#show'
 
       # caretaker list tasks
       get '/caretakers/:id/lists/:list_id/tasks', to: 'caretakers/tasks#index'

--- a/spec/requests/api/v1/caretakers/lists/list_show_spec.rb
+++ b/spec/requests/api/v1/caretakers/lists/list_show_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe "List API show endpoint" do
+  before :each do
+    @caretaker_1 = Caretaker.create({
+      'username': 'caretaker_1',
+      'password': 'password',
+      'password_confirmation': 'password',
+      'name': 'caretaker_uno',
+      'email': 'kate@email.com',
+      'phone_number': '1234567891',
+      'abilities': 'ability_1, ability_2',
+      'role': 'caretaker'
+    })
+    @client = create(:client)
+    @list1 = create(:list, client: @client, caretaker_id: @caretaker_1.id)
+    @list2 = create(:list, client: @client, caretaker_id: @caretaker_1.id)
+
+  end
+  it "gets a single list associated with given caretaker" do
+    get "/api/v1/caretakers/#{@caretaker_1.id}/lists/#{@list1.id}"
+
+    list = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(list).to have_key(:name)
+    expect(list).to have_key(:client_id)
+    expect(list).to have_key(:caretaker_id)
+    expect(list).to have_key(:created_at)
+    expect(list).to have_key(:updated_at)
+  end
+
+  it "returns 404 if client does not exist" do
+    get "/api/v1/caretakers/invalid_id/lists/#{@list1.id}"
+
+    expect(status).to eq(404)
+
+    error = JSON.parse(response.body, symbolize_names: true)
+
+    expect(error[:message]).to eq("Not Found")
+  end
+
+  it "returns 404 if list does not exist" do
+    get "/api/v1/caretakers/#{@caretaker_1.id}/lists/invalid_id"
+
+    expect(status).to eq(404)
+
+    error = JSON.parse(response.body, symbolize_names: true)
+
+    expect(error[:message]).to eq("Not Found")
+  end
+end


### PR DESCRIPTION
## What functionality does this accomplish?
User can send a GET request to receive a single list
​
**Description:**
​When a user provides a valid caretaker and list ID, and makes a request to:
GET '/api/v1/caretakers/:id/lists/:list_id' 
A single list will be returned, with status code of 200

If an invalid caretaker or list ID is provided, a 404 will be returned

## Current Test Suite:
### Test Coverage Percentage: 98.29%
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):
​
## Checklist:
- [ ] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):